### PR TITLE
Use server t step for state update

### DIFF
--- a/Sim_CLI/main.py
+++ b/Sim_CLI/main.py
@@ -149,12 +149,15 @@ def predict_action(req: StateRequest):
         
         current_cgm_raw = req.history[-1][0]
         previous_insulin_action_raw = req.history[-1][1]
-        current_hour_raw = req.hour # JavaScript에서 받은 현재 시간(시)
+        current_hour_raw = req.hour  # JavaScript에서 받은 현재 시간(시)
         current_meal_raw = req.meal if req.meal is not None else 0.0
 
-        print(f"INFO:     [LOG_MAIN_RAW_INPUTS_TO_STATESPACE] Raw inputs for StateSpace.update(): "
-              f"cgm={current_cgm_raw:.2f}, ins(prev_action)={previous_insulin_action_raw:.4f}, "
-              f"hour={current_hour_raw:.1f}, meal={current_meal_raw:.1f}")
+        print(
+            f"INFO:     [LOG_MAIN_RAW_INPUTS_TO_STATESPACE] Raw inputs for StateSpace.update(): "
+            f"cgm={current_cgm_raw:.2f}, ins(prev_action)={previous_insulin_action_raw:.4f}, "
+            f"hour_from_req={current_hour_raw:.1f}, t_step_for_state={current_t_step}, "
+            f"meal={current_meal_raw:.1f}"
+        )
 
         if not (np.isfinite(current_cgm_raw) and
                 np.isfinite(previous_insulin_action_raw) and
@@ -166,9 +169,9 @@ def predict_action(req: StateRequest):
             cgm=current_cgm_raw,
             ins=previous_insulin_action_raw,
             meal=current_meal_raw,
-            hour=current_hour_raw,
-            meal_type=0, 
-            carbs=0      
+            hour=current_t_step,
+            meal_type=0,
+            carbs=0
         )
         
         print(f"INFO:     [LOG_MAIN_STATESPACE_OUTPUT] StateSpace.update() returned: \n"
@@ -218,7 +221,10 @@ def predict_action(req: StateRequest):
             with open(LOG_FILE_PATH, 'a', newline='') as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=SimglucoseLogHeader)
                 writer.writerow(log_row_dict)
-            print(f"INFO:     [LOG_MAIN_CSV_WRITE] Successfully wrote to {LOG_FILE_PATH}: (epi={log_row_dict['epi']}, t={log_row_dict['t']})")
+            print(
+                f"INFO:     [LOG_MAIN_CSV_WRITE] Successfully wrote to {LOG_FILE_PATH}: "
+                f"(epi={log_row_dict['epi']}, t_step={log_row_dict['t']}, req_hour={current_hour_raw})"
+            )
         except Exception as csv_e:
             print(f"ERROR:    [LOG_MAIN_CSV_WRITE] Failed to write Simglucose format log: {csv_e}", file=sys.stderr)
         # ---------------------------------

--- a/Sim_CLI/test_main.py
+++ b/Sim_CLI/test_main.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from .main import app
+from .main import app, app_state
 
 client = TestClient(app)
 
@@ -12,7 +12,7 @@ def example_history():
     ]
 
 def test_predict_action_success():
-    payload = {"history": example_history()}
+    payload = {"history": example_history(), "hour": 10}
     response = client.post("/predict_action", json=payload)
     assert response.status_code == 200, response.text
     data = response.json()
@@ -23,7 +23,7 @@ def test_predict_action_success():
 def test_predict_action_failure_shape():
     # history의 shape가 이상할 때(11개)
     wrong_history = example_history()[:-1]
-    payload = {"history": wrong_history}
+    payload = {"history": wrong_history, "hour": 0}
     response = client.post("/predict_action", json=payload)
     assert response.status_code == 500
     assert "history 형상 오류" in response.json()["detail"]
@@ -31,7 +31,21 @@ def test_predict_action_failure_shape():
 def test_predict_action_nan():
     nan_history = example_history()
     nan_history[2][0] = float("nan")
-    payload = {"history": nan_history}
+    payload = {"history": nan_history, "hour": 0}
     response = client.post("/predict_action", json=payload)
     assert response.status_code == 500
     assert "입력 NaN/Inf" in response.json()["detail"]
+
+
+def test_predict_action_counter_ignored_hour():
+    app_state["api_call_counter"] = 0
+    payload1 = {"history": example_history(), "hour": 5}
+    resp1 = client.post("/predict_action", json=payload1)
+    assert resp1.status_code == 200
+    assert app_state["api_call_counter"] == 1
+
+    payload2 = {"history": example_history(), "hour": 99}
+    resp2 = client.post("/predict_action", json=payload2)
+    assert resp2.status_code == 200
+    # Counter should increment regardless of provided hour
+    assert app_state["api_call_counter"] == 2


### PR DESCRIPTION
## Summary
- use API call counter as hour when updating StateSpace
- clarify logs to display request hour vs internal step
- update tests to provide hour and verify internal counter

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement simglucose==0.2.2)*
- `pytest -q Sim_CLI/test_main.py` *(fails: command not found)*

## Sourcery 요약

StateSpace를 업데이트할 때 서버 측 API 호출 카운터를 시간 단계로 사용하고, 상태 업데이트를 위해 클라이언트가 제공한 시간은 무시하며, 요청된 시간과 내부 단계를 구별하기 위해 로깅을 개선합니다.

개선 사항:
- StateSpace.update를 호출할 때 제공된 시간 대신 내부 API 호출 카운터(t_step)를 사용합니다.
- 요청 시간과 내부 시간 단계를 모두 표시하도록 콘솔 로그를 개선합니다.
- 내부 시간 단계와 원래 요청 시간을 모두 CSV 쓰기 로그에 포함합니다.

테스트:
- 기존 테스트를 위해 요청 페이로드에 "hour"가 필요합니다.
- 제공된 시간과 관계없이 API 호출 카운터가 증가하는지 확인하는 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use the server-side API call counter as the time step when updating the StateSpace, ignore the client-provided hour for state updates, and improve logging to distinguish between the requested hour and the internal step.

Enhancements:
- Use the internal API call counter (t_step) instead of the provided hour when calling StateSpace.update
- Enhance console logs to show both the request hour and the internal time step
- Include both the internal time step and the original request hour in the CSV write log

Tests:
- Require "hour" in request payloads for existing tests
- Add a test to verify the API call counter increments regardless of the provided hour

</details>