### PR TITLE
Remove scaling and adjust tests

### DIFF
--- a/Sim_CLI/main.py
+++ b/Sim_CLI/main.py
@@ -187,8 +187,7 @@ def predict_action(req: StateRequest):
             hc_state_processed=processed_hc_state_np
         )
 
-        ## !!! 위 수치가 인슐린 수치에 해당함. 
-        action_U_per_h *= 100
+        ## !!! 위 수치가 인슐린 수치에 해당함.
 
         print(f"INFO:     [LOG_MAIN_FINAL_ACTION_FROM_API] Action from infer_action (to be returned to JS): {action_U_per_h:.4f} U/h")
 
@@ -223,7 +222,7 @@ def predict_action(req: StateRequest):
             print(f"ERROR:    [LOG_MAIN_CSV_WRITE] Failed to write Simglucose format log: {csv_e}", file=sys.stderr)
         # ---------------------------------
 
-        return {"insulin_action_U_per_h": action_U_per_h}
+        return ActionResponse(insulin_action_U_per_h=action_U_per_h)
 
     except ValueError as ve:
         print(f"\n!!! ValueError processing /predict_action: {ve} !!!", file=sys.stderr)

--- a/Sim_CLI/test_main.py
+++ b/Sim_CLI/test_main.py
@@ -16,7 +16,7 @@ def test_predict_action_success():
     response = client.post("/predict_action", json=payload)
     assert response.status_code == 200, response.text
     data = response.json()
-    # 행동값이 범위 내인지 체크 (0.0 ~ 5.0)
+    # 행동값이 범위 내인지 체크 (0.0 ~ 5.0 U/h)
     assert "insulin_action_U_per_h" in data
     assert 0.0 <= data["insulin_action_U_per_h"] <= 5.0
 


### PR DESCRIPTION
## Summary
- drop insulin scaling from `predict_action`
- return `ActionResponse` directly
- update unit test comment for 0–5 U/h range

## Testing
- `pytest -q` *(fails: `pytest` not installed)*

## Sourcery 요약

predict_action에서 인슐린 스케일링을 제거하고, ActionResponse를 반환하도록 변경하며, 인슐린 단위 범위를 명확히 하기 위해 테스트를 업데이트합니다.

버그 수정:
- predict_action에서 수동 인슐린 스케일링 곱셈 제거

개선 사항:
- predict_action에서 원시 dict 대신 타입이 지정된 ActionResponse 반환

테스트:
- 인슐린 작용 범위(U/h)를 명시하도록 단위 테스트 주석 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove insulin scaling from predict_action, switch to returning ActionResponse, and update tests to clarify insulin unit range

Bug Fixes:
- Remove manual insulin scaling multiplier in predict_action

Enhancements:
- Return typed ActionResponse instead of raw dict in predict_action

Tests:
- Update unit test comment to specify insulin action range in U/h

</details>