### PR TITLE
Fix action scaling conversion

### DIFF
--- a/Sim_CLI/g2p2c_agent_api.py
+++ b/Sim_CLI/g2p2c_agent_api.py
@@ -167,30 +167,20 @@ def infer_action(
     # scaled_action = action_obj.get_action(action_from_model, ...)
     # 여기서는 action_type='exponential', action_scale=5 (parameters.py에서 설정된 args 값)
     # exponential 변환: action_scale * exp((model_output - 1) * 4)
-    # (참고: G2P2C/utils/pumpAction.py 에 PumpAction 클래스가 있다면 해당 로직 사용)
-    
-    # 가정: G2P2C/utils/pumpAction.py에 PumpAction 클래스가 있고, get_action 메소드가 있다고 가정
-    # 이 부분이 없다면, 직접 변환 로직 구현 필요
-    try:
-        from utils.pumpAction import PumpAction # pumpAction.py가 utils 폴더에 있다고 가정
-        action_converter = PumpAction(agent.args.action_scale, agent.args.action_type)
-        # PumpAction.get_action은 model_output (-1~1)을 받아 스케일링된 액션을 반환
-        # model_output은 1차원 tensor 또는 scalar여야 할 수 있음.
-        final_action_U_per_h = action_converter.get_action(torch.tensor([raw_action_model_output], device=agent.device))
-        final_action_U_per_h = float(final_action_U_per_h.item()) # 텐서에서 float 값 추출
-    except ImportError:
-        print("WARNING: utils.pumpAction.PumpAction not found. Using direct exponential scaling as a fallback. This might differ from training.", file=sys.stderr)
-        # Fallback: 직접 exponential 변환 (G2P2C Worker에서 사용되는 방식과 유사하게)
-        # args.action_scale은 agents/g2p2c/parameters.py에서 5로 설정됨.
-        # action_type은 커맨드라인에서 'exponential'로 주어짐.
-        if agent.args.action_type == 'exponential':
-            final_action_U_per_h = agent.args.action_scale * np.exp((raw_action_model_output - 1) * 4)
-        else:
-            # 다른 action_type에 대한 처리 (예: linear scaling)
-            # (raw_action_model_output + 1) / 2 * (agent.args.insulin_max - agent.args.insulin_min) + agent.args.insulin_min
-            # 지금은 exponential만 고려
-            print(f"WARNING: Action type '{agent.args.action_type}' scaling not explicitly implemented in API fallback. Using raw model output scaled by action_scale.", file=sys.stderr)
-            final_action_U_per_h = raw_action_model_output * agent.args.action_scale # 단순 스케일링 (정확하지 않을 수 있음)
+    # (참고: G2P2C/utils/pumpAction.Pump 클래스의 'action' 메서드와 동일한 지수 변환 규칙 적용)
+    if agent.args.action_type == 'exponential':
+        final_action_U_per_h = agent.args.action_scale * np.exp((raw_action_model_output - 1) * 4)
+    elif agent.args.action_type == 'normal':
+        final_action_U_per_h = (raw_action_model_output + 1) / 2 * agent.args.action_scale
+    elif agent.args.action_type == 'sparse':
+        final_action_U_per_h = max(0.0, raw_action_model_output) * agent.args.action_scale
+    else:
+        # 기타 스케일링 방식은 학습 코드와 동일하게 구현돼 있지 않으므로 단순 스케일링 사용
+        print(
+            f"WARNING: Action type '{agent.args.action_type}' not fully supported. Using linear scaling as fallback.",
+            file=sys.stderr,
+        )
+        final_action_U_per_h = raw_action_model_output * agent.args.action_scale
 
     # 최종적으로 insulin_min, insulin_max 범위로 클리핑
     action_clipped = float(np.clip(final_action_U_per_h, agent.args.insulin_min, agent.args.insulin_max))


### PR DESCRIPTION
## Summary
- fix `Sim_CLI/g2p2c_agent_api.py` to remove nonexistent PumpAction usage
- implement scaling logic directly for supported action types

## Testing
- `pytest -q` *(fails: command not found)*

## Sourcery 요약

외부 `PumpAction` 클래스에 대한 의존성을 제거하고 지원되는 모든 액션 유형에 대해 직접적인 액션 스케일링 로직을 구현합니다.

버그 수정:
- 존재하지 않는 `PumpAction` 모듈의 import 및 사용을 제거합니다.

개선 사항:
- 지원되지 않는 유형에 대한 선형 폴백(linear fallback)과 함께 인라인 지수(exponential), 정규(normal) 및 희소(sparse) 스케일링 규칙을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove reliance on external PumpAction class and implement direct action scaling logic for all supported action types

Bug Fixes:
- Eliminate import and use of nonexistent PumpAction module

Enhancements:
- Add inline exponential, normal, and sparse scaling rules with a linear fallback for unsupported types

</details>