### PR TITLE
Add Korean docs for Sim_CLI

### DIFF
--- a/Sim_CLI/main.py
+++ b/Sim_CLI/main.py
@@ -1,4 +1,11 @@
 # Sim_CLI/main.py
+"""FastAPI 서버를 구동하여 DMMS.R 시뮬레이터와 G2P2C 에이전트 사이를 중계한다.
+
+DMMS.R 에서 JavaScript 플러그인을 통해 호출되는 ``/predict_action`` 엔드포인트를
+제공하며, 에이전트 초기화와 CSV 로그 저장 기능을 담당한다. 해당 서버를 실행한
+상태에서 DMMS.R 시뮬레이션을 수행하면 매 5분마다 인슐린 주입량을 예측하여
+응답한다.
+"""
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -38,6 +45,7 @@ SimglucoseLogHeader = [
 app_state: Dict = {}
 
 def format_log_data(data):
+    """CSV 로 기록하기 위해 NumPy/Tensor 객체를 파이썬 기본 타입으로 변환한다."""
     if isinstance(data, np.ndarray):
         return data.tolist()
     if isinstance(data, torch.Tensor):
@@ -50,6 +58,11 @@ def format_log_data(data):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    """애플리케이션 시작과 종료 시 필요한 초기화를 담당한다.
+
+    G2P2C 에이전트를 로드하고 ``StateSpace`` 를 생성하며, CSV 로그 파일의
+    헤더를 준비한다. ``yield`` 이후에는 종료 처리를 수행한다.
+    """
     print("INFO:     Application startup...")
     app_state["api_call_counter"] = 0 # API 호출 횟수 카운터 (t 스텝으로 사용)
     app_state["current_episode"] = 1   # 현재 에피소드 번호 (기본값)
@@ -126,6 +139,7 @@ app.add_middleware(
 
 @app.post("/predict_action", response_model=ActionResponse)
 def predict_action(req: StateRequest):
+    """에이전트에게 상태를 전달하고 인슐린 주입률을 응답받는 엔드포인트."""
     agent = app_state.get("agent")
     state_space = app_state.get("state_space_instance")
     agent_args = app_state.get("agent_args_for_statespace")

--- a/Sim_CLI/run_dmms_cli.py
+++ b/Sim_CLI/run_dmms_cli.py
@@ -1,0 +1,57 @@
+"""DMMS.R 시뮬레이터를 명령행에서 한 번 실행하기 위한 간단한 스크립트."""
+
+import argparse
+from pathlib import Path
+import subprocess
+import pandas as pd
+
+
+def run_dmms(exe: Path, cfg: Path, log: Path, results_dir: Path) -> None:
+    """CLI 모드로 DMMS.R을 한 번 실행하고 결과 CSV 파일 경로를 출력한다."""
+    exe = Path(exe)
+    cfg = Path(cfg)
+    log = Path(log)
+    results_dir = Path(results_dir)
+
+    cmd = [str(exe), str(cfg), str(log), str(results_dir)]
+    print(f"Running: {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"DMMS.R failed with code {e.returncode}")
+        raise
+
+    if not results_dir.is_dir():
+        raise FileNotFoundError(f"Results directory not found: {results_dir}")
+
+    csv_files = list(results_dir.glob('*.csv'))
+    if not csv_files:
+        print(f"No CSV files found in {results_dir}")
+    else:
+        print(f"Generated CSV files:")
+        for f in csv_files:
+            print(f" - {f}")
+
+        # Example of loading the first CSV file
+        try:
+            df = pd.read_csv(csv_files[0])
+            print(f"Loaded {csv_files[0]} with {len(df)} rows")
+        except Exception as e:
+            print(f"Failed to load {csv_files[0]}: {e}")
+
+
+def main():
+    """커맨드라인 인자를 파싱하여 ``run_dmms`` 함수를 호출한다."""
+
+    parser = argparse.ArgumentParser(description="Run DMMS.R via CLI")
+    parser.add_argument("exe", type=Path, help="Path to DMMS.R executable")
+    parser.add_argument("cfg", type=Path, help="Path to config XML")
+    parser.add_argument("log", type=Path, help="Path to log file")
+    parser.add_argument("results", type=Path, help="Directory for results")
+    args = parser.parse_args()
+
+    run_dmms(args.exe, args.cfg, args.log, args.results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add high-level module descriptions and docstrings in Korean
- expand comments in RL_Agent_Plugin_v1.0.js
- document run_dmms_cli helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: torch, httpx, gym, simglucose, pandas)*

## Sourcery 요약

Sim_CLI 패키지의 핵심 기능 및 모듈에 한국어 문서 및 주석을 추가하고, DMMS.R의 명령줄 실행을 위한 run_dmms_cli 헬퍼 스크립트를 도입합니다.

새로운 기능:
- CLI를 통해 DMMS.R을 한 번 실행하고 생성된 CSV 결과를 보고하는 run_dmms_cli 헬퍼 스크립트 추가

문서:
- g2p2c_agent_api.load_agent 및 infer_action 함수에 한국어 독스트링 추가
- main.py 함수의 format_log_data, lifespan 및 predict_action에 한국어 독스트링 추가
- RL_Agent_Plugin_v1.0.js의 주석을 번역하고 확장하여 플러그인 수명 주기 및 상태 준비 기능에 대한 한국어 설명을 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Korean-language documentation and comments to core functions and modules in the Sim_CLI package and introduce a run_dmms_cli helper script for command-line execution of DMMS.R

New Features:
- Add run_dmms_cli helper script for executing DMMS.R once via CLI and reporting generated CSV results

Documentation:
- Add Korean docstrings to g2p2c_agent_api.load_agent and infer_action functions
- Add Korean docstrings to main.py functions format_log_data, lifespan, and predict_action
- Translate and expand comments in RL_Agent_Plugin_v1.0.js with Korean explanations for plugin lifecycle and state preparation functions

</details>