### PR TITLE
Add episode termination handling

### DIFF
--- a/Sim_CLI/RL_Agent_Plugin_v1.0.js
+++ b/Sim_CLI/RL_Agent_Plugin_v1.0.js
@@ -263,6 +263,19 @@ function cleanup() {
     isInitialized = false;
     lastAppliedAction_UperH = 0.0;
     current_rate_for_minute_application_U_per_H = 0.0;
+    try {
+        var success = httpWebServiceInvoker.performPostRequest(
+            AGENT_API_URL + "/episode_end",
+            "{}",
+            "application/json",
+            WEB_REQUEST_TIMEOUT_MS
+        );
+        if (!success) {
+            debugLog += "\n[Cleanup] Failed to notify /episode_end.";
+        }
+    } catch(e) {
+        debugLog += "\n[Cleanup] Exception during /episode_end POST: " + e;
+    }
     // debugLog += "\n[Cleanup] Globals reset."; // 필요시 로그 추가
 }
 

--- a/Sim_CLI/run_dmms_cli.py
+++ b/Sim_CLI/run_dmms_cli.py
@@ -1,0 +1,53 @@
+import argparse
+from pathlib import Path
+import subprocess
+import pandas as pd
+
+
+def run_dmms(exe: Path, cfg: Path, log: Path, results_dir: Path) -> None:
+    """Run DMMS.R simulator once using CLI and print path to generated CSV files."""
+    exe = Path(exe)
+    cfg = Path(cfg)
+    log = Path(log)
+    results_dir = Path(results_dir)
+
+    cmd = [str(exe), str(cfg), str(log), str(results_dir)]
+    print(f"Running: {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"DMMS.R failed with code {e.returncode}")
+        raise
+
+    if not results_dir.is_dir():
+        raise FileNotFoundError(f"Results directory not found: {results_dir}")
+
+    csv_files = list(results_dir.glob('*.csv'))
+    if not csv_files:
+        print(f"No CSV files found in {results_dir}")
+    else:
+        print(f"Generated CSV files:")
+        for f in csv_files:
+            print(f" - {f}")
+
+        # Example of loading the first CSV file
+        try:
+            df = pd.read_csv(csv_files[0])
+            print(f"Loaded {csv_files[0]} with {len(df)} rows")
+        except Exception as e:
+            print(f"Failed to load {csv_files[0]}: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run DMMS.R via CLI")
+    parser.add_argument("exe", type=Path, help="Path to DMMS.R executable")
+    parser.add_argument("cfg", type=Path, help="Path to config XML")
+    parser.add_argument("log", type=Path, help="Path to log file")
+    parser.add_argument("results", type=Path, help="Directory for results")
+    args = parser.parse_args()
+
+    run_dmms(args.exe, args.cfg, args.log, args.results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- track experience buffer in FastAPI app
- compute reward from next CGM value and store state/action in buffer
- reset and return experience via new `/episode_end` endpoint
- notify server of episode completion from JS plugin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

## Sourcery 요약

FastAPI 서버에서 상태-행동-보상 경험을 추적하고, `composite_reward`로 보상을 계산하며, 새로운 `/episode_end` 엔드포인트를 통해 상태를 재설정하여 에피소드 종료 처리를 추가합니다. JS 플러그인이 정리(cleanup) 시 이 엔드포인트를 트리거하도록 활성화하고, DMMS.R 시뮬레이터를 실행하고 CSV 출력을 보고하는 CLI 도구를 도입합니다.

새로운 기능:
- FastAPI 앱에서 에피소드 경험 추적을 도입하고 새로운 `/episode_end` 엔드포인트를 통해 노출합니다.
- JS 플러그인을 확장하여 정리 시 `/episode_end`를 호출하고 서버에 에피소드 완료를 알립니다.
- DMMS.R 시뮬레이터를 시작하고 생성된 CSV 결과를 수집 및 표시하는 `run_dmms_cli.py` 유틸리티를 추가합니다.

개선 사항:
- `composite_reward`를 통합하여 경험 버퍼에 단계별 보상과 최종 보상을 계산하고 저장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add episode termination handling by tracking state-action-reward experiences in the FastAPI server, computing rewards with `composite_reward`, and resetting state via a new `/episode_end` endpoint; enable the JS plugin to trigger this endpoint on cleanup; and introduce a CLI tool to run the DMMS.R simulator and report CSV outputs.

New Features:
- Introduce episode experience tracking in the FastAPI app and expose it via a new `/episode_end` endpoint.
- Extend the JS plugin to call `/episode_end` upon cleanup and notify the server of episode completion.
- Add `run_dmms_cli.py` utility for launching the DMMS.R simulator, collecting and displaying generated CSV results.

Enhancements:
- Integrate `composite_reward` to compute and store per-step and final rewards in the experience buffer.

</details>