### PR TITLE
Add env_step API endpoint

### DIFF
--- a/Sim_CLI/RL_Agent_Plugin_v1.0.js
+++ b/Sim_CLI/RL_Agent_Plugin_v1.0.js
@@ -182,7 +182,7 @@ function runIteration(subjObject, sensorSigArray, nextMealObject, nextExerciseOb
         try {
             var requestBody = JSON.stringify(agentState);
             var contentType = "application/json";
-            var success = httpWebServiceInvoker.performPostRequest(AGENT_API_URL + "/predict_action", requestBody, contentType, WEB_REQUEST_TIMEOUT_MS);
+            var success = httpWebServiceInvoker.performPostRequest(AGENT_API_URL + "/env_step", requestBody, contentType, WEB_REQUEST_TIMEOUT_MS);
 
             if (success && !httpWebServiceInvoker.timeout() && httpWebServiceInvoker.responseStatusCode() >= 200 && httpWebServiceInvoker.responseStatusCode() < 300) {
                 var responseBody = httpWebServiceInvoker.responseBody();

--- a/Sim_CLI/test/test_main.py
+++ b/Sim_CLI/test/test_main.py
@@ -11,41 +11,41 @@ def example_history():
         [122.7, 0.18], [124.9, 0.20], [125.0, 0.25], [126.1, 0.27]
     ]
 
-def test_predict_action_success():
+def test_env_step_success():
     payload = {"history": example_history(), "hour": 10}
-    response = client.post("/predict_action", json=payload)
+    response = client.post("/env_step", json=payload)
     assert response.status_code == 200, response.text
     data = response.json()
     # 행동값이 범위 내인지 체크 (0.0 ~ 5.0 U/h)
     assert "insulin_action_U_per_h" in data
     assert 0.0 <= data["insulin_action_U_per_h"] <= 5.0
 
-def test_predict_action_failure_shape():
+def test_env_step_failure_shape():
     # history의 shape가 이상할 때(11개)
     wrong_history = example_history()[:-1]
     payload = {"history": wrong_history, "hour": 0}
-    response = client.post("/predict_action", json=payload)
+    response = client.post("/env_step", json=payload)
     assert response.status_code == 500
     assert "history 형상 오류" in response.json()["detail"]
 
-def test_predict_action_nan():
+def test_env_step_nan():
     nan_history = example_history()
     nan_history[2][0] = float("nan")
     payload = {"history": nan_history, "hour": 0}
-    response = client.post("/predict_action", json=payload)
+    response = client.post("/env_step", json=payload)
     assert response.status_code == 500
     assert "입력 NaN/Inf" in response.json()["detail"]
 
 
-def test_predict_action_counter_ignored_hour():
+def test_env_step_counter_ignored_hour():
     app_state["api_call_counter"] = 0
     payload1 = {"history": example_history(), "hour": 5}
-    resp1 = client.post("/predict_action", json=payload1)
+    resp1 = client.post("/env_step", json=payload1)
     assert resp1.status_code == 200
     assert app_state["api_call_counter"] == 1
 
     payload2 = {"history": example_history(), "hour": 99}
-    resp2 = client.post("/predict_action", json=payload2)
+    resp2 = client.post("/env_step", json=payload2)
     assert resp2.status_code == 200
     # Counter should increment regardless of provided hour
     assert app_state["api_call_counter"] == 2


### PR DESCRIPTION
## Summary
- introduce `/env_step` endpoint in FastAPI server
- alias existing `/predict_action` to reuse the new logic
- save experience buffer to `results/dmms_experience` on episode end
- update JavaScript plugin to call `/env_step`
- adjust tests to target `/env_step`

## Testing
- `pytest Sim_CLI/test/test_main.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

## Sourcery 요약

RL 스텝 처리를 위한 새로운 `/env_step` 엔드포인트를 도입하고 기존 `/predict_action` 엔드포인트를 별칭으로 지정하여 재사용합니다. 에피소드 종료 시 에피소드 경험 버퍼를 JSON으로 저장하고, JavaScript 플러그인과 테스트를 업데이트하여 새로운 엔드포인트를 사용하도록 합니다.

새로운 기능:
- 공유 스텝 처리 로직을 기반으로 하는 `/env_step` 엔드포인트 추가
- 기존 `/predict_action` 엔드포인트를 별칭으로 지정하여 새로운 핸들러를 재사용하여 이전 버전과의 호환성 유지
- 에피소드 종료 시 경험 버퍼를 `results/dmms_experience/episode_{n}.json`에 저장

개선 사항:
- 스텝 처리 로직을 공통 `_handle_env_step` 함수로 리팩토링하고 동적 엔드포인트 이름을 사용하도록 로깅 업데이트
- RL JavaScript 플러그인을 업데이트하여 `/predict_action` 대신 `/env_step` 호출

테스트:
- 테스트 이름을 변경하고 `/env_step`을 대상으로 조정하여 스텝 카운터, 입력 모양 및 NaN 처리를 검증

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new `/env_step` endpoint for RL step processing and alias the existing `/predict_action` endpoint to it, persist episode experience buffers as JSON on episode end, and update the JavaScript plugin and tests to use the new endpoint.

New Features:
- Add `/env_step` endpoint backed by shared step-handling logic
- Alias existing `/predict_action` endpoint to reuse the new handler for backward compatibility
- Persist experience buffer to `results/dmms_experience/episode_{n}.json` on episode end

Enhancements:
- Refactor step-processing logic into a common `_handle_env_step` function and update logging to use dynamic endpoint names
- Update the RL JavaScript plugin to call `/env_step` instead of `/predict_action`

Tests:
- Rename and adjust tests to target `/env_step` and validate step counter, input shape, and NaN handling

</details>