### PR TITLE
Add DMMS environment wrapper

### DIFF
--- a/Sim_CLI/RL_Agent_Plugin_v1.0.js
+++ b/Sim_CLI/RL_Agent_Plugin_v1.0.js
@@ -182,7 +182,7 @@ function runIteration(subjObject, sensorSigArray, nextMealObject, nextExerciseOb
         try {
             var requestBody = JSON.stringify(agentState);
             var contentType = "application/json";
-            var success = httpWebServiceInvoker.performPostRequest(AGENT_API_URL + "/predict_action", requestBody, contentType, WEB_REQUEST_TIMEOUT_MS);
+            var success = httpWebServiceInvoker.performPostRequest(AGENT_API_URL + "/env_step", requestBody, contentType, WEB_REQUEST_TIMEOUT_MS);
 
             if (success && !httpWebServiceInvoker.timeout() && httpWebServiceInvoker.responseStatusCode() >= 200 && httpWebServiceInvoker.responseStatusCode() < 300) {
                 var responseBody = httpWebServiceInvoker.responseBody();

--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -1,0 +1,71 @@
+import subprocess
+from pathlib import Path
+from typing import Any, Tuple, Dict
+
+import gym
+import numpy as np
+import httpx
+
+
+class DmmsEnv(gym.Env):
+    """Gym 호환 환경 래퍼.
+
+    DMMS.R 프로세스를 관리하고 FastAPI 서버와 통신한다.
+    실제 시뮬레이터와 API 동작 시나리오에 맞춰 수정이 필요하다.
+    """
+
+    metadata = {"render.modes": []}
+
+    def __init__(self, api_url: str, exe: Path, cfg: Path, log_path: Path, results_root: Path) -> None:
+        super().__init__()
+        self.api_url = api_url.rstrip("/")
+        self.exe = Path(exe)
+        self.cfg = Path(cfg)
+        self.log_path = Path(log_path)
+        self.results_root = Path(results_root)
+        self.proc: subprocess.Popen | None = None
+        self.episode = 0
+        self.results_root.mkdir(parents=True, exist_ok=True)
+
+    def _start_process(self, results_dir: Path) -> None:
+        cmd = [str(self.exe), str(self.cfg), str(self.log_path), str(results_dir)]
+        self.proc = subprocess.Popen(cmd)
+
+    def _terminate_process(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+        self.proc = None
+
+    def reset(self) -> Any:
+        """시뮬레이터를 새로 시작하고 초기 상태를 반환한다."""
+        self.close()
+        self.episode += 1
+        self.results_dir = self.results_root / f"episode_{self.episode}"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        self._start_process(self.results_dir)
+        # 초기 상태는 외부 플러그인을 통해 서버로 전달되므로 이곳에서는 None 반환
+        return None
+
+    def step(self, action: float) -> Tuple[Any, float, bool, Dict]:
+        """FastAPI 서버의 /env_step을 호출한다."""
+        payload = {"action": action}
+        try:
+            resp = httpx.post(f"{self.api_url}/env_step", json=payload, timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            return None, np.nan, True, {}
+
+        obs = data.get("next_state")
+        reward = float(data.get("reward", 0.0))
+        done = bool(data.get("done", False))
+        return obs, reward, done, {}
+
+    def close(self) -> None:
+        self._terminate_process()
+

--- a/Sim_CLI/test/test_episode_end.py
+++ b/Sim_CLI/test/test_episode_end.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from Sim_CLI.main import app, app_state
+from pathlib import Path
+import json
+
+client = TestClient(app)
+
+def test_episode_end_creates_file(tmp_path):
+    # Ensure buffer has one experience
+    app_state["experience_buffer"] = [{"state": {}, "action": 0.0, "reward": 0.0, "next_state": None}]
+    app_state["current_episode"] = 99
+    resp = client.post("/episode_end")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["episode"] == 99
+    exp_path = Path("results/dmms_experience/episode_99.json")
+    assert exp_path.is_file()
+    with open(exp_path) as f:
+        saved = json.load(f)
+    assert isinstance(saved, list)

--- a/Sim_CLI/test/test_main.py
+++ b/Sim_CLI/test/test_main.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from .main import app, app_state
+from Sim_CLI.main import app, app_state
 
 client = TestClient(app)
 
@@ -11,41 +11,41 @@ def example_history():
         [122.7, 0.18], [124.9, 0.20], [125.0, 0.25], [126.1, 0.27]
     ]
 
-def test_predict_action_success():
+def test_env_step_success():
     payload = {"history": example_history(), "hour": 10}
-    response = client.post("/predict_action", json=payload)
+    response = client.post("/env_step", json=payload)
     assert response.status_code == 200, response.text
     data = response.json()
     # 행동값이 범위 내인지 체크 (0.0 ~ 5.0 U/h)
     assert "insulin_action_U_per_h" in data
     assert 0.0 <= data["insulin_action_U_per_h"] <= 5.0
 
-def test_predict_action_failure_shape():
+def test_env_step_failure_shape():
     # history의 shape가 이상할 때(11개)
     wrong_history = example_history()[:-1]
     payload = {"history": wrong_history, "hour": 0}
-    response = client.post("/predict_action", json=payload)
+    response = client.post("/env_step", json=payload)
     assert response.status_code == 500
     assert "history 형상 오류" in response.json()["detail"]
 
-def test_predict_action_nan():
+def test_env_step_nan():
     nan_history = example_history()
     nan_history[2][0] = float("nan")
     payload = {"history": nan_history, "hour": 0}
-    response = client.post("/predict_action", json=payload)
+    response = client.post("/env_step", json=payload)
     assert response.status_code == 500
     assert "입력 NaN/Inf" in response.json()["detail"]
 
 
-def test_predict_action_counter_ignored_hour():
+def test_env_step_counter_ignored_hour():
     app_state["api_call_counter"] = 0
     payload1 = {"history": example_history(), "hour": 5}
-    resp1 = client.post("/predict_action", json=payload1)
+    resp1 = client.post("/env_step", json=payload1)
     assert resp1.status_code == 200
     assert app_state["api_call_counter"] == 1
 
     payload2 = {"history": example_history(), "hour": 99}
-    resp2 = client.post("/predict_action", json=payload2)
+    resp2 = client.post("/env_step", json=payload2)
     assert resp2.status_code == 200
     # Counter should increment regardless of provided hour
     assert app_state["api_call_counter"] == 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ torchaudio==2.2.0+cu118
 torchvision==0.17.0+cu118
 tornado==6.4.2
 
+httpx==0.27.0

--- a/utils/options.py
+++ b/utils/options.py
@@ -29,6 +29,13 @@ class Options:
                                  help='patient_id = [adolescent child adults] hence 0 - 9 indexes adolescents likewise')
         self.parser.add_argument('--sensor', type=str, default='GuardianRT', help='Dexcom, GuardianRT, Navigator')
         self.parser.add_argument('--pump', type=str, default='Insulet', help='Insulet, Cozmo')
+        self.parser.add_argument('--sim', type=str, default='simglucose',
+                                 help='simglucose | dmms')
+        self.parser.add_argument('--dmms_exe', type=str, default='', help='Path to DMMS.R executable')
+        self.parser.add_argument('--dmms_cfg', type=str, default='', help='Path to DMMS.R config XML')
+        self.parser.add_argument('--dmms_log', type=str, default='dmms_log.txt', help='DMMS.R log file')
+        self.parser.add_argument('--dmms_results', type=str, default='dmms_results', help='Output root directory')
+        self.parser.add_argument('--dmms_api_url', type=str, default='http://127.0.0.1:5000', help='FastAPI server URL')
 
         # for training: # ideal benchmark adult and adolescent doesnt have snacks though => set prob '-1' to remove
         self.parser.add_argument('--meal_prob', type=list, default=[0.95, -1, 0.95, -1, 0.95, -1], help='')


### PR DESCRIPTION
## Summary
- add a Gym wrapper `DmmsEnv` to launch DMMS.R and call the FastAPI server
- support `--sim dmms` option and new DMMS paths in `utils.options`
- select the DMMS environment in `utils.core.get_env`
- fix test imports and add `/episode_end` test
- list `httpx` in requirements

## Testing
- `pytest Sim_CLI/test/test_main.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest Sim_CLI/test/test_episode_end.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

## Sourcery 요약

DMMS를 시뮬레이션 백엔드로 활성화하기 위해 Gym 환경 래퍼를 추가하고, CLI 옵션을 확장하고, 새로운 `/env_step` 엔드포인트를 노출하고, 공유 API 로직을 리팩토링하고, 에피소드 종료 시 경험 지속성을 보장합니다.

새로운 기능:
- DMMS.R 프로세스를 관리하고 FastAPI를 통해 통신하기 위해 DmmsEnv Gym 래퍼를 추가합니다.
- `--sim dmms` 및 관련 CLI 인수로 DMMS 시뮬레이션 모드를 지원합니다.
- 기존 predict_action과 함께 환경 상호 작용을 위한 `/env_step` API 엔드포인트를 도입합니다.
- `/episode_end` 시 경험 버퍼를 JSON 파일에 유지합니다.

버그 수정:
- 올바른 모듈 경로를 참조하도록 테스트 import를 수정합니다.

개선 사항:
- 공통 API 단계 로직을 `_handle_env_step` 도우미로 리팩토링합니다.
- DmmsEnv를 `get_env` 선택 로직에 통합합니다.

빌드:
- httpx를 프로젝트 요구 사항에 추가합니다.

테스트:
- `/env_step` 엔드포인트를 사용하고 API 호출 카운터를 검증하도록 테스트를 업데이트합니다.
- `/episode_end` 파일 생성을 위한 새로운 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DMMS as a simulation backend by adding a Gym environment wrapper, extending CLI options, exposing a new `/env_step` endpoint, refactoring shared API logic, and ensuring experience persistence on episode end.

New Features:
- Add DmmsEnv Gym wrapper to manage DMMS.R process and communicate via FastAPI
- Support DMMS simulation mode with `--sim dmms` and related CLI arguments
- Introduce `/env_step` API endpoint for environment interactions alongside existing predict_action
- Persist experience buffer to a JSON file on `/episode_end`

Bug Fixes:
- Fix test imports to reference the correct module path

Enhancements:
- Refactor common API step logic into `_handle_env_step` helper
- Integrate DmmsEnv into `get_env` selection logic

Build:
- Add httpx to project requirements

Tests:
- Update tests to use `/env_step` endpoint and validate API call counter
- Add new test for `/episode_end` file creation

</details>