### PR TITLE
Implement DMMS environment wrapper

### DIFF
--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -1,0 +1,63 @@
+import subprocess
+from pathlib import Path
+from typing import Any, Tuple
+
+import gym
+from gym import spaces
+import httpx
+
+
+class DmmsEnv(gym.Env):
+    """Gym wrapper for interacting with DMMS.R via FastAPI."""
+
+    metadata = {"render.modes": []}
+
+    def __init__(self, server_url: str, exe_path: str, cfg_path: str, io_root: str):
+        super().__init__()
+        self.server_url = server_url.rstrip("/")
+        self.exe_path = str(exe_path)
+        self.cfg_path = str(cfg_path)
+        self.io_root = Path(io_root)
+        self.io_root.mkdir(parents=True, exist_ok=True)
+        self.episode_counter = 0
+        self.proc: subprocess.Popen | None = None
+
+        self.action_space = spaces.Box(low=0.0, high=5.0, shape=(1,), dtype=float)
+        self.observation_space = spaces.Box(low=-float("inf"), high=float("inf"), shape=(12, 2), dtype=float)
+
+    def _start_process(self, results_dir: Path) -> None:
+        log_file = results_dir / "dmms.log"
+        cmd = [self.exe_path, self.cfg_path, str(log_file), str(results_dir)]
+        self.proc = subprocess.Popen(cmd)
+
+    def reset(self) -> Any:
+        self.close()
+        self.episode_counter += 1
+        self.results_dir = self.io_root / f"episode_{self.episode_counter}"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        self._start_process(self.results_dir)
+        resp = httpx.get(f"{self.server_url}/get_state")
+        resp.raise_for_status()
+        return resp.json()["obs"]
+
+    def step(self, action: Any) -> Tuple[Any, float, bool, dict]:
+        payload = {"action": action}
+        resp = httpx.post(f"{self.server_url}/env_step", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        obs = data.get("obs")
+        reward = data.get("reward", 0.0)
+        done = data.get("done", False)
+        info = data.get("info", {})
+        return obs, reward, done, info
+
+    def close(self) -> None:
+        if self.proc is not None:
+            if self.proc.poll() is None:
+                self.proc.terminate()
+                try:
+                    self.proc.wait(15)
+                except subprocess.TimeoutExpired:
+                    self.proc.kill()
+                    self.proc.wait()
+            self.proc = None

--- a/experiments/run_RL_agent.py
+++ b/experiments/run_RL_agent.py
@@ -167,8 +167,23 @@ def main():
     random.seed(args.seed)
     np.random.seed(args.seed)
 
-    patients, env_ids = get_patient_env()  # note: left here so that type of subject can be selected.
-    agent.run(args, patients, env_ids, args.seed)
+    if args.sim == 'dmms':
+        from Sim_CLI.dmms_env import DmmsEnv
+        env = DmmsEnv(
+            server_url=args.dmms_server,
+            exe_path=args.dmms_exe,
+            cfg_path=args.dmms_cfg,
+            io_root=args.dmms_io,
+        )
+        obs = env.reset()
+        done = False
+        while not done:
+            action = env.action_space.sample()
+            obs, reward, done, _ = env.step(action)
+        env.close()
+    else:
+        patients, env_ids = get_patient_env()  # note: left here so that type of subject can be selected.
+        agent.run(args, patients, env_ids, args.seed)
 
 
 if __name__ == '__main__':

--- a/utils/options.py
+++ b/utils/options.py
@@ -30,6 +30,18 @@ class Options:
         self.parser.add_argument('--sensor', type=str, default='GuardianRT', help='Dexcom, GuardianRT, Navigator')
         self.parser.add_argument('--pump', type=str, default='Insulet', help='Insulet, Cozmo')
 
+        # dmms simulator selection
+        self.parser.add_argument('--sim', type=str, default='simglucose',
+                                 help='simglucose or dmms')
+        self.parser.add_argument('--dmms_server', type=str, default='http://localhost:8000',
+                                 help='FastAPI server URL for DMMS.R')
+        self.parser.add_argument('--dmms_exe', type=str, default='',
+                                 help='Path to DMMS.R executable')
+        self.parser.add_argument('--dmms_cfg', type=str, default='',
+                                 help='Path to DMMS.R config XML file')
+        self.parser.add_argument('--dmms_io', type=str, default='results/dmms_runs',
+                                 help='Directory for DMMS logs and results')
+
         # for training: # ideal benchmark adult and adolescent doesnt have snacks though => set prob '-1' to remove
         self.parser.add_argument('--meal_prob', type=list, default=[0.95, -1, 0.95, -1, 0.95, -1], help='')
         self.parser.add_argument('--meal_amount', type=list, default=[45, 30, 85, 30, 80, 30], help='')


### PR DESCRIPTION
## Summary
- create `DmmsEnv` Gym wrapper for DMMS.R
- add simulator selection options to `Options`
- integrate new env into `run_RL_agent.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' and others)*

## Sourcery 요약

DMMS Gym 환경 래퍼를 구현하고 RL 에이전트 러너에 선택적 시뮬레이터로 통합합니다.

새로운 기능:
- DMMS.R 하위 프로세스를 시작하고 FastAPI 엔드포인트를 통해 통신하는 DmmsEnv Gym 래퍼 클래스 추가
- 서버 URL, 실행 파일 경로, 구성 파일 및 I/O 디렉토리에 대한 매개변수와 함께 'dmms' 시뮬레이터 모드를 선택할 수 있도록 명령줄 옵션 확장
- '--sim dmms'가 지정되면 DmmsEnv를 인스턴스화하고 사용하도록 run_RL_agent 스크립트를 수정하여 간단한 상호 작용 루프 실행

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a DMMS Gym environment wrapper and integrate it as an optional simulator in the RL agent runner

New Features:
- Add DmmsEnv Gym wrapper class to launch DMMS.R subprocess and communicate via FastAPI endpoints
- Extend command-line options to support selecting 'dmms' simulator mode with parameters for server URL, executable path, config file, and I/O directory
- Modify run_RL_agent script to instantiate and use DmmsEnv when '--sim dmms' is specified, executing a simple interaction loop

</details>