### PR TITLE
Add environment APIs and tests

### DIFF
--- a/Sim_CLI/tests/test_api.py
+++ b/Sim_CLI/tests/test_api.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from Sim_CLI.main import app, app_state
+
+client = TestClient(app)
+
+
+def test_get_state_returns_last_cgm():
+    app_state['last_cgm'] = 123.0
+    resp = client.get('/get_state')
+    assert resp.status_code == 200
+    assert resp.json()['cgm'] == 123.0
+
+
+def test_env_step_updates_state_and_returns_reward():
+    app_state['last_cgm'] = 150.0
+    resp = client.post('/env_step', json={'action': 1.0})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'cgm' in data and 'reward' in data and 'done' in data
+    assert data['cgm'] == app_state['last_cgm']


### PR DESCRIPTION
## Summary
- support DMMS env with `/get_state` and new `/env_step`
- adjust server-side data structures for stub environment transitions
- provide basic tests for the new endpoints

## Testing
- `pytest Sim_CLI/tests/test_api.py -q` *(fails: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version)*

## Sourcery 요약

DMMS 환경 엔드포인트를 추가하여 현재 CGM 상태를 검색하고 환경을 단계별로 실행하며, 서버 상태를 업데이트하고 보상을 계산합니다. 또한 이러한 API에 대한 기본적인 테스트를 포함합니다.

새로운 기능:
- 최신 CGM 값을 반환하는 GET /get_state 엔드포인트 도입
- EnvStepRequest/EnvStepResponse 모델을 사용하여 액션을 적용하고 다음 상태, 보상, 완료 플래그 및 정보를 반환하는 POST /env_step 엔드포인트 추가

개선 사항:
- API 호출 횟수, 마지막 CGM, 이전 상태/액션 및 경험 버퍼를 app_state에서 추적
- 에이전트 인수를 사용할 수 있는 경우 복합 보상을 계산하고 app_state를 적절히 업데이트

테스트:
- GET /get_state가 저장된 CGM 값을 반환하는지 확인하는 테스트 추가
- POST /env_step이 상태를 업데이트하고 CGM, 보상 및 완료 필드를 반환하는지 확인하는 테스트 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add DMMS environment endpoints to retrieve current CGM state and step through the environment, updating server state and computing rewards, and include basic tests for these APIs.

New Features:
- Introduce GET /get_state endpoint to return the latest CGM value
- Add POST /env_step endpoint with EnvStepRequest/EnvStepResponse models to apply actions and return next state, reward, done flag, and info

Enhancements:
- Track API call count, last CGM, previous state/action, and experience buffer in app_state
- Compute composite rewards when agent arguments are available and update app_state accordingly

Tests:
- Add tests verifying GET /get_state returns the stored CGM value
- Add tests verifying POST /env_step updates state and returns CGM, reward, and done fields

</details>