### PR TITLE
Enable DMMS training path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,6 +89,16 @@ cd experiments
 python run_RL_agent.py --agent g2p2c --folder_id test --patient_id 0 --return_type average --action_type exponential --device cpu --seed 3 --debug 0
 ```
 
+### Training with DMMS.R
+
+To train using the external **DMMS.R** simulator start the FastAPI server and run the RL script with `--sim dmms`.
+Mandatory arguments are the DMMS executable and configuration paths:
+
+```
+cd experiments
+python run_RL_agent.py --sim dmms --dmms_exe /path/DMMS.R.exe --dmms_cfg /path/Sim_CLI.xml --agent g2p2c
+```
+
 
 
 <h4>Running Experiments</h4>

--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -44,8 +44,20 @@ class DmmsEnv(gym.Env):
         resp.raise_for_status()
         data = resp.json()
         obs_val = data.get("cgm")
+        info = data.get("info", {})
+        default_info = {
+            "sample_time": 1,
+            "future_carb": 0,
+            "remaining_time": 0,
+            "day_hour": 0,
+            "day_min": 0,
+            "meal_type": 0,
+            "meal": 0,
+        }
+        if isinstance(info, dict):
+            default_info.update(info)
         obs = self.Observation(CGM=obs_val)
-        return self.Step(observation=obs, reward=0.0, done=False, info={})
+        return self.Step(observation=obs, reward=0.0, done=False, info=default_info)
 
     def step(self, action: Any) -> Step:
         payload = {"action": action}
@@ -56,8 +68,19 @@ class DmmsEnv(gym.Env):
         reward = data.get("reward", 0.0)
         done = data.get("done", False)
         info = data.get("info", {})
+        default_info = {
+            "sample_time": 1,
+            "future_carb": 0,
+            "remaining_time": 0,
+            "day_hour": 0,
+            "day_min": 0,
+            "meal_type": 0,
+            "meal": 0,
+        }
+        if isinstance(info, dict):
+            default_info.update(info)
         obs = self.Observation(CGM=obs_val)
-        return self.Step(observation=obs, reward=reward, done=done, info=info)
+        return self.Step(observation=obs, reward=reward, done=done, info=default_info)
 
     def close(self) -> None:
         if self.proc is not None:

--- a/experiments/run_RL_agent.py
+++ b/experiments/run_RL_agent.py
@@ -6,6 +6,7 @@ import shutil
 import random
 import numpy as np
 import argparse
+from pathlib import Path
 from pprint import pprint
 from decouple import config
 MAIN_PATH = config('MAIN_PATH')
@@ -38,6 +39,18 @@ def copy_folder(src, dst):
     for folders, subfolders, filenames in os.walk(src):
         for filename in filenames:
             shutil.copy(os.path.join(folders, filename), dst)
+
+
+def setup_dmms_dirs(args):
+    """Create result directories for DMMS runs if they don't exist."""
+    paths = [
+        Path('results/dmms_experience'),
+        Path('results/dmms_realtime_logs'),
+        Path('results/dmms_realtime_logs_v2'),
+        Path(args.dmms_io),
+    ]
+    for p in paths:
+        p.mkdir(parents=True, exist_ok=True)
 
 
 def set_agent_parameters(args):
@@ -173,22 +186,10 @@ def main():
     np.random.seed(args.seed)
 
     if args.sim == 'dmms':
-        from Sim_CLI.dmms_env import DmmsEnv
-        env = DmmsEnv(
-            server_url=args.dmms_server,
-            exe_path=args.dmms_exe,
-            cfg_path=args.dmms_cfg,
-            io_root=args.dmms_io,
-        )
-        obs = env.reset()
-        done = False
-        while not done:
-            action = env.action_space.sample()
-            obs, reward, done, _ = env.step(action)
-        env.close()
-    else:
-        patients, env_ids = get_patient_env()  # note: left here so that type of subject can be selected.
-        agent.run(args, patients, env_ids, args.seed)
+        setup_dmms_dirs(args)
+
+    patients, env_ids = get_patient_env()  # note: left here so that type of subject can be selected.
+    agent.run(args, patients, env_ids, args.seed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add directory creation for DMMS runs
- simplify run_RL_agent to use same agent loop when `--sim dmms`
- extend DmmsEnv with info fields for Worker compatibility
- document DMMS usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

## Sourcery 요약

필요한 디렉토리를 자동 생성하고, DMMS에 대한 에이전트 루프를 통합하고, DMMS 환경 정보 필드를 확장하고, 사용법을 문서화하여 DMMS 기반 훈련을 활성화합니다.

새로운 기능:
- `--sim dmms`를 통해 외부 DMMS 시뮬레이터로 훈련을 지원합니다.
- DMMS 실행에 필요한 결과 디렉토리를 자동으로 생성합니다.

개선 사항:
- DMMS 훈련을 통합하여 사용자 정의 시뮬레이션 루프 대신 표준 에이전트 루프를 사용합니다.
- Worker 호환성을 위해 기본 정보 필드를 포함하도록 DmmsEnv를 확장합니다.

문서:
- README에서 DMMS 훈련 사용법 및 필수 플래그를 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DMMS-based training by auto-creating required directories, unifying the agent loop for DMMS, extending DMMS environment info fields, and documenting usage.

New Features:
- Support training with the external DMMS simulator via `--sim dmms`
- Automatically create necessary result directories for DMMS runs

Enhancements:
- Unify DMMS training to use the standard agent loop instead of a custom simulation loop
- Extend DmmsEnv to include default info fields for Worker compatibility

Documentation:
- Document DMMS training usage and required flags in the README

</details>