### PR TITLE
Fix Box dtype issue in DMMS environment

### DIFF
--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -26,8 +26,13 @@ class DmmsEnv(gym.Env):
         self.episode_counter = 0
         self.proc: subprocess.Popen | None = None
 
-        self.action_space = spaces.Box(low=0.0, high=5.0, shape=(1,), dtype=float)
-        self.observation_space = spaces.Box(low=-float("inf"), high=float("inf"), shape=(12, 2), dtype=float)
+        # older versions of ``gym`` do not accept the ``dtype`` argument in
+        # ``spaces.Box``.  Since the exact version used can vary, rely on the
+        # default dtype to maximise compatibility.
+        self.action_space = spaces.Box(low=0.0, high=5.0, shape=(1,))
+        self.observation_space = spaces.Box(
+            low=-float("inf"), high=float("inf"), shape=(12, 2)
+        )
 
     def _start_process(self, results_dir: Path) -> None:
         log_file = results_dir / "dmms.log"


### PR DESCRIPTION
## Summary
- ensure `DmmsEnv` is compatible with older `gym` versions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

## Sourcery 요약

버그 수정:
- 이전 Gym 릴리스와의 호환성을 유지하기 위해 action_space 및 observation_space Box 정의에서 명시적인 dtype 매개변수를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove explicit dtype parameters from action_space and observation_space Box definitions to maintain compatibility with older Gym releases

</details>