### PR TITLE
Update requirements with FastAPI deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,6 @@ torch==2.2.0+cu118
 torchaudio==2.2.0+cu118
 torchvision==0.17.0+cu118
 tornado==6.4.2
+fastapi==0.110.0
+httpx==0.27.0
 


### PR DESCRIPTION
## Summary
- include FastAPI and httpx packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

## Sourcery 요약

빌드:
- FastAPI 0.110.0 및 httpx 0.27.0을 requirements.txt에 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add FastAPI 0.110.0 and httpx 0.27.0 to requirements.txt

</details>