### PR TITLE
Improve DMMS env reset connection logic

### DIFF
--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -1,6 +1,7 @@
 import subprocess
+import time
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 from collections import namedtuple
 
 import gym
@@ -25,6 +26,8 @@ class DmmsEnv(gym.Env):
         self.io_root.mkdir(parents=True, exist_ok=True)
         self.episode_counter = 0
         self.proc: subprocess.Popen | None = None
+        self._max_connect_attempts = 20
+        self._connect_interval = 0.5
 
         # older versions of ``gym`` do not accept the ``dtype`` argument in
         # ``spaces.Box``.  Since the exact version used can vary, rely on the
@@ -45,8 +48,24 @@ class DmmsEnv(gym.Env):
         self.results_dir = self.io_root / f"episode_{self.episode_counter}"
         self.results_dir.mkdir(parents=True, exist_ok=True)
         self._start_process(self.results_dir)
-        resp = httpx.get(f"{self.server_url}/get_state")
-        resp.raise_for_status()
+        last_error: Exception | None = None
+        for _ in range(self._max_connect_attempts):
+            try:
+                resp = httpx.get(f"{self.server_url}/get_state")
+                resp.raise_for_status()
+                break
+            except Exception as e:
+                last_error = e
+                if self.proc is not None and self.proc.poll() is not None:
+                    raise RuntimeError(
+                        "DMMS.R process terminated before handshake"
+                    ) from e
+                time.sleep(self._connect_interval)
+        else:
+            raise RuntimeError(
+                f"Failed to connect to {self.server_url}/get_state after {self._max_connect_attempts} attempts"
+            ) from last_error
+
         data = resp.json()
         obs_val = data.get("cgm")
         info = data.get("info", {})


### PR DESCRIPTION
## Summary
- retry `/get_state` a few times in `DmmsEnv.reset`
- raise clear error if the FastAPI server cannot be reached

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

## Sourcery 요약

DMMSEnv.reset을 개선하여 /get_state 핸드셰이크에 대해 구성 가능한 시도 횟수와 간격으로 재시도 루프를 구현하고, 서버 프로세스가 종료되거나 연결에 실패할 경우 명확한 오류를 제공합니다.

개선 사항:
- DMMSEnv에 구성 가능한 max_connect_attempts 및 connect_interval 도입
- 재설정 시 최대 시도 횟수까지 지정된 sleep 간격으로 /get_state 요청 재시도
- DMMS 프로세스가 조기에 종료되거나 모든 재시도 후에도 응답하지 않으면 명시적인 RuntimeError 발생

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance DMMSEnv.reset to implement a retry loop with configurable attempts and interval for the /get_state handshake, and provide clear errors when the server process dies or fails to connect.

Enhancements:
- Introduce configurable max_connect_attempts and connect_interval to DMMSEnv
- Retry the /get_state request on reset up to max attempts with a sleep interval
- Raise explicit RuntimeError if the DMMS process terminates prematurely or fails to respond after all retries

</details>