### PR TITLE
Send episode_end request in close()

### DIFF
--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -1,11 +1,15 @@
 import subprocess
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 from collections import namedtuple
+
+import logging
 
 import gym
 from gym import spaces
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class DmmsEnv(gym.Env):
@@ -89,6 +93,11 @@ class DmmsEnv(gym.Env):
 
     def close(self) -> None:
         if self.proc is not None:
+            try:
+                httpx.post(f"{self.server_url}/episode_end")
+            except Exception as exc:
+                logger.warning("Failed to notify episode end: %s", exc)
+
             if self.proc.poll() is None:
                 self.proc.terminate()
                 try:


### PR DESCRIPTION
## Summary
- notify FastAPI server when closing `DmmsEnv`
- warn if notification fails

## Testing
- `pytest -q` *(fails: ImportError while importing fastapi.testclient)*

## Sourcery 요약

DmmsEnv가 종료될 때 FastAPI 서버에 episode_end 요청을 보내고 오류를 정상적으로 처리합니다.

개선 사항:
- 환경을 닫을 때 FastAPI 서버에 HTTP POST를 보내 에피소드 종료를 알립니다.
- 알림 요청이 실패하면 경고를 기록합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Notify the FastAPI server when DmmsEnv is closed by sending an episode_end request and gracefully handle failures

Enhancements:
- Send an HTTP POST to the FastAPI server on closing the environment to notify episode end
- Log a warning if the notification request fails

</details>