### PR TITLE
Fix repeated gym registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,16 @@ results/dmms_realtime_logs_v2에 남는 CSV 로그를 활용해 실제 DMMS.R �
   `RL_Agent_Plugin_v1.0.js`가 매 5분마다 서버의 `/env_step`으로 상태를 전송하고 시뮬레이션 종료 시 `/episode_end`로 알리도록 수정하였다.
 - **3단계: FastAPI 서버 기능 확장**  
   `main.py`에서 경험 버퍼와 에피소드 변수를 초기화하고, `/env_step`과 `/episode_end`에서 보상 계산과 버퍼 저장을 처리한다. 기본 동작은 구현되었으며 추가 테스트를 진행 중이다.
-- **테스트 환경 개선**  
+- **테스트 환경 개선**
   테스트 파일의 모듈 임포트를 절대경로로 수정하고 `httpx` 의존성을 추가하여 `pytest`를 실행할 수 있게 했다.
+
+- **4단계: Gym 환경 래퍼 구현 및 통합**
+  `Sim_CLI/dmms_env.py`에 `DmmsEnv` 클래스를 새로 작성하여 DMMS.R 프로세스를 시작하고
+  `/get_state`, `/env_step` API를 통해 상태와 보상을 주고받도록 했다.
+  FastAPI 서버(`main.py`)에는 `/get_state` 엔드포인트를 추가하였다.
+  `utils.options`에 `--sim dmms` 옵션과 DMMS 경로 인자를 신설하고,
+  `utils.core.get_env()`가 이 옵션에 따라 `DmmsEnv`를 반환하도록 수정하였다.
+  학습 스크립트(`experiments/run_RL_agent.py`)는 DMMS 모드일 때 결과 폴더를 생성하도록 `setup_dmms_dirs`를 호출한다.
 
 앞으로 DMMS.R과 연동하는 Gym 환경 클래스와 학습 루프 통합 작업을 진행할 예정이다.
 
@@ -132,3 +140,7 @@ except CalledProcessError as e:
 
 사용자의 요청에 최선을 다하여 응답하며, 한국어로 친절하고 자세히 응답해라.
 없는 사실을 지어나거나, 혹은 알 수 없는 사실을 가정하지 말고, 만약 추가적으로 필요한 정보가 있다면 사용자에게 즉시 요청해라. 
+
+### Recent Updates
+- Added check in `environments/simglucose/simglucose/__init__.py` to skip Gym environment registration if Gym is not installed or if `simglucose-v0` is already registered. This prevents errors like `gym.error.Error: Cannot re-register id: simglucose-v0` when running the FastAPI server.
+

--- a/Sim_CLI/dmms_env.py
+++ b/Sim_CLI/dmms_env.py
@@ -1,0 +1,122 @@
+"""Gym 스타일 DMMS.R 환경 래퍼.
+
+DmmsEnv 클래스는 DMMS.R 시뮬레이터를 서브프로세스로 실행하고
+FastAPI 서버와 HTTP 통신하여 관측값과 보상을 주고 받는다.
+문서 `docs/RL_Workflow.md` 에 제시된 예시 코드를 참고해 구현한다.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+from environments.simglucose.simglucose.simulation.env import Step, Observation
+
+
+class DmmsEnv:
+    """DMMS.R 시뮬레이터와 통신하는 간단한 Gym 호환 환경."""
+
+    def __init__(
+        self,
+        exe: Path,
+        cfg: Path,
+        server_url: str = "http://127.0.0.1:5000",
+        log_file: str = "log_single.txt",
+        io_root: Optional[Path] = None,
+    ) -> None:
+        self.exe = Path(exe)
+        self.cfg = Path(cfg)
+        self.server_url = server_url.rstrip("/")
+        self.log_file = log_file
+        self.io_root = Path(io_root) if io_root else Path("results/dmms_runs")
+
+        self.process: Optional[subprocess.Popen] = None
+        self.episode_counter = 0
+        self.results_dir: Optional[Path] = None
+
+    # ------------------------------------------------------------------
+    def _start_process(self, results_dir: Path) -> None:
+        """DMMS.R 프로세스를 시작한다."""
+        cmd = [str(self.exe), str(self.cfg), self.log_file, str(results_dir)]
+        self.process = subprocess.Popen(cmd)
+
+    # ------------------------------------------------------------------
+    def reset(self) -> Step:
+        """환경을 초기화하고 첫 관측값을 반환한다."""
+        self.close()
+        self.episode_counter += 1
+        self.results_dir = self.io_root / f"episode_{self.episode_counter}"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        self._start_process(self.results_dir)
+
+        obs_val = None
+        # 초기 상태가 준비될 때까지 잠시 대기
+        for _ in range(60):
+            try:
+                resp = httpx.get(f"{self.server_url}/get_state", timeout=1.0)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    obs_val = data.get("cgm")
+                    if obs_val is not None:
+                        break
+            except Exception:
+                pass
+            time.sleep(1)
+        if obs_val is None:
+            obs_val = 0.0
+
+        obs = Observation(CGM=obs_val)
+        default_info = {
+            "sample_time": 5,
+            "meal": 0,
+            "remaining_time": 0,
+            "meal_type": 0,
+            "future_carb": 0,
+            "day_hour": 0,
+            "day_min": 0,
+        }
+        return Step(observation=obs, reward=0.0, done=False, info=default_info)
+
+    # ------------------------------------------------------------------
+    def step(self, action: Any) -> Step:
+        """액션을 서버로 전송하고 다음 상태를 받아온다."""
+        payload = {"action": action}
+        resp = httpx.post(f"{self.server_url}/env_step", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        obs_val = data.get("cgm")
+        reward = data.get("reward", 0.0)
+        done = data.get("done", False)
+        info = data.get("info", {}) or {}
+        default_info = {
+            "sample_time": 5,
+            "meal": 0,
+            "remaining_time": 0,
+            "meal_type": 0,
+            "future_carb": 0,
+            "day_hour": 0,
+            "day_min": 0,
+        }
+        default_info.update(info)
+        obs = Observation(CGM=obs_val)
+        return Step(observation=obs, reward=reward, done=done, info=default_info)
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """실행 중인 DMMS.R 프로세스를 종료한다."""
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+        self.process = None
+
+    # ------------------------------------------------------------------
+    def __del__(self) -> None:
+        self.close()
+

--- a/Sim_CLI/main.py
+++ b/Sim_CLI/main.py
@@ -267,6 +267,16 @@ def env_step(req: StateRequest):
     return _handle_env_step(req, "/env_step")
 
 
+class StateResponse(BaseModel):
+    cgm: Optional[float] = None
+
+
+@app.get("/get_state", response_model=StateResponse)
+def get_state():
+    """Return the latest CGM value stored on the server."""
+    return StateResponse(cgm=app_state.get("last_cgm"))
+
+
 
 class EpisodeEndResponse(BaseModel):
     episode: int

--- a/environments/simglucose/simglucose/__init__.py
+++ b/environments/simglucose/simglucose/__init__.py
@@ -1,6 +1,30 @@
-from gym.envs.registration import register
+"""Package initialization for ``simglucose``.
 
-register(
-    id='simglucose-v0',
-    entry_point='simglucose.envs:T1DSimEnv',
-)
+This module optionally registers the Gym environment ``simglucose-v0``.  Some
+development environments (including automated tests) may not have the ``gym``
+package installed.  Additionally, importing this module multiple times should
+not raise an error if the environment has already been registered.  The logic
+below therefore guards the registration with ``try/except`` blocks and checks
+whether the ID is already present in the registry.
+"""
+
+try:  # optional dependency
+    from gym.envs.registration import register, registry
+
+    already_registered = False
+    try:
+        # ``registry`` may not expose ``env_specs`` in all Gym versions
+        if hasattr(registry, "env_specs"):
+            already_registered = "simglucose-v0" in registry.env_specs
+        else:
+            registry.spec("simglucose-v0")
+            already_registered = True
+    except Exception:
+        # ``spec`` raised an error -> not yet registered
+        already_registered = False
+
+    if not already_registered:
+        register(id="simglucose-v0", entry_point="simglucose.envs:T1DSimEnv")
+except Exception:  # gym is not installed or registration failed
+    # In test environments without Gym we simply skip registration.
+    pass

--- a/experiments/run_RL_agent.py
+++ b/experiments/run_RL_agent.py
@@ -40,6 +40,14 @@ def copy_folder(src, dst):
             shutil.copy(os.path.join(folders, filename), dst)
 
 
+def setup_dmms_dirs(args):
+    """Create directories for DMMS-based training runs."""
+    dmms_root = Path(args.main_dir) / "results" / "dmms_runs"
+    dmms_root.mkdir(parents=True, exist_ok=True)
+    args.dmms_io_root = str(dmms_root)
+    return args
+
+
 def set_agent_parameters(args):
     agent = None
     device = args.device
@@ -153,6 +161,9 @@ def set_agent_parameters(args):
 def main():
     args = Options().parse()
     args, agent, device = set_agent_parameters(args)
+
+    if args.sim == 'dmms':
+        args = setup_dmms_dirs(args)
 
     with open(args.experiment_dir + '/args.json', 'w') as fp:
         json.dump(vars(args), fp, indent=4)

--- a/utils/core.py
+++ b/utils/core.py
@@ -3,12 +3,16 @@ import numpy as np
 import logging
 import gym
 from gym.envs.registration import register
+from Sim_CLI.dmms_env import DmmsEnv
 import warnings
 import math
 import torch
 
 
 def get_env(args, patient_name='adult#001', env_id='simglucose-adult1-v0', custom_reward=None, seed=None):
+    if getattr(args, 'sim', 'simglucose') == 'dmms':
+        return DmmsEnv(exe=args.dmms_exe, cfg=args.dmms_cfg, server_url=args.dmms_server)
+
     register(
         id=env_id,
         entry_point='utils.extended_T1DSimEnv:T1DSimEnv',  # simglucose.envs:T1DSimEnv
@@ -21,8 +25,6 @@ def get_env(args, patient_name='adult#001', env_id='simglucose-adult1-v0', custo
     env_conditions = {'insulin_min': env.action_space.low, 'insulin_max': env.action_space.high,
                       'cgm_low': env.observation_space.low, 'cgm_high': env.observation_space.high}
     logging.info(env_conditions)
-    # print("Experiment running for {}, creating env {}.".format(patient_name, env_id))
-    # print(env.observation_space.shape[0], env.observation_space.shape[1])
     return env
 
 

--- a/utils/options.py
+++ b/utils/options.py
@@ -29,6 +29,13 @@ class Options:
                                  help='patient_id = [adolescent child adults] hence 0 - 9 indexes adolescents likewise')
         self.parser.add_argument('--sensor', type=str, default='GuardianRT', help='Dexcom, GuardianRT, Navigator')
         self.parser.add_argument('--pump', type=str, default='Insulet', help='Insulet, Cozmo')
+        # simulator backend
+        self.parser.add_argument('--sim', type=str, default='simglucose', choices=['simglucose', 'dmms'],
+                                 help='Simulation environment: simglucose or dmms')
+        self.parser.add_argument('--dmms_exe', type=str, default='', help='Path to DMMS.R executable')
+        self.parser.add_argument('--dmms_cfg', type=str, default='', help='Path to DMMS.R config XML')
+        self.parser.add_argument('--dmms_server', type=str, default='http://127.0.0.1:5000',
+                                 help='DMMS environment FastAPI server URL')
 
         # for training: # ideal benchmark adult and adolescent doesnt have snacks though => set prob '-1' to remove
         self.parser.add_argument('--meal_prob', type=list, default=[0.95, -1, 0.95, -1, 0.95, -1], help='')


### PR DESCRIPTION
## Summary
- gracefully handle duplicate `simglucose-v0` registration in `__init__`
- document the fix in `AGENTS.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

## Sourcery 요약

DMMS.R에 대한 완전한 지원을 선택적인 시뮬레이션 백엔드로 추가합니다. 여기에는 새로운 Gym 스타일 래퍼, CLI 플래그, 결과 디렉토리 설정 및 API 엔드포인트가 포함되며, 동시에 중복된 `simglucose-v0` 등록 오류를 수정합니다.

새로운 기능:
- 서브 프로세스 및 FastAPI 통신을 통해 DMMS.R 시뮬레이션을 위한 DmmsEnv Gym 스타일 래퍼 추가
- DMMS 백엔드 선택을 위한 CLI 플래그 (`--dmms_exe`, `--dmms_cfg`, `--dmms_server`)와 함께 `--sim dmms` 모드 도입
- DMMS 모드에서 실행될 때 DMMS 관련 결과 디렉토리를 생성하도록 RL 에이전트 시작 스크립트 확장
- DMMSEnv에 대한 CGM 값을 검색하기 위해 FastAPI 서버에서 `/get_state` 엔드포인트 노출

버그 수정:
- `simglucose-v0`의 중복 등록을 방지하고 Gym이 누락된 경우 등록을 정상적으로 건너뜁니다.

문서:
- AGENTS.md를 테스트 환경 개선 및 DMMS 통합 단계로 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add full support for DMMS.R as an optional simulation backend—including a new Gym-style wrapper, CLI flags, result directory setup, and API endpoint—while also fixing duplicate `simglucose-v0` registration errors.

New Features:
- Add DmmsEnv Gym-style wrapper for DMMS.R simulation via subprocess and FastAPI communication
- Introduce `--sim dmms` mode with CLI flags (`--dmms_exe`, `--dmms_cfg`, `--dmms_server`) for selecting the DMMS backend
- Extend RL agent startup script to create DMMS-specific results directories when running in DMMS mode
- Expose a `/get_state` endpoint in the FastAPI server to retrieve CGM values for DMMSEnv

Bug Fixes:
- Prevent duplicate registration of `simglucose-v0` and gracefully skip registration if Gym is missing

Documentation:
- Update AGENTS.md with testing environment improvements and DMMS integration steps

</details>