### PR TITLE
Fix DMMS RL environment interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,4 +143,6 @@ except CalledProcessError as e:
 
 ### Recent Updates
 - Added check in `environments/simglucose/simglucose/__init__.py` to skip Gym environment registration if Gym is not installed or if `simglucose-v0` is already registered. This prevents errors like `gym.error.Error: Cannot re-register id: simglucose-v0` when running the FastAPI server.
+- `Sim_CLI/main.py` now returns an extended step response (`StepResponse`) containing `cgm`, `reward`, `done`, and `info` fields in addition to `insulin_action_U_per_h`. This helps `DmmsEnv` interact with the API like a Gym environment.
+- `DmmsEnv` tracks the latest CGM value and updates it after each step. The environment also uses `args.dmms_io_root` from `utils.core.get_env()` so results are saved under `results/dmms_runs`.
 

--- a/utils/core.py
+++ b/utils/core.py
@@ -11,7 +11,12 @@ import torch
 
 def get_env(args, patient_name='adult#001', env_id='simglucose-adult1-v0', custom_reward=None, seed=None):
     if getattr(args, 'sim', 'simglucose') == 'dmms':
-        return DmmsEnv(exe=args.dmms_exe, cfg=args.dmms_cfg, server_url=args.dmms_server)
+        return DmmsEnv(
+            exe=args.dmms_exe,
+            cfg=args.dmms_cfg,
+            server_url=args.dmms_server,
+            io_root=getattr(args, 'dmms_io_root', None),
+        )
 
     register(
         id=env_id,


### PR DESCRIPTION
## Summary
- extend FastAPI server response with Step info for RL
- track last CGM in `DmmsEnv` and save results under `dmms_io_root`
- pass `dmms_io_root` to environment through `get_env`
- document new API and env changes in `AGENTS.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

## Sourcery 요약

FastAPI에서 확장된 RL 스텝 인터페이스를 구현하고, 새로운 RL 필드와 결과 지속성을 지원하도록 DmmsEnv를 개선합니다.

새로운 기능:
- `/env_step` 및 `/predict_action` 엔드포인트에서 cgm, reward, done, info를 포함하는 확장된 스텝 응답을 반환합니다.

개선 사항:
- 결과 출력 디렉토리를 제어하기 위해 dmms_io_root를 DmmsEnv에 전달합니다.
- DmmsEnv 내에서 마지막 CGM 값을 추적하고 API 응답에서 cgm이 생략된 경우 이를 대체 값으로 사용합니다.

문서:
- AGENTS.md를 업데이트하여 새로운 스텝 응답 형식과 io_root 구성을 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement extended RL step interface in FastAPI and enhance DmmsEnv to support new RL fields and result persistence.

New Features:
- Return extended step response with cgm, reward, done, and info from /env_step and /predict_action endpoints.

Enhancements:
- Pass dmms_io_root into DmmsEnv to control results output directory.
- Track last CGM value within DmmsEnv and use it as fallback when the API response omits cgm.

Documentation:
- Update AGENTS.md to describe the new step response format and io_root configuration.

</details>